### PR TITLE
Kp/everloop

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 matrixio-kernel-modules (0.1.4) unstable; urgency=low
 
   * Bug Fix: Zwave UART Has been fixed
+  * Bug Fix: Change led order from GRWB to RGBW and use buffer write function.
   * Support microphone core: 128 Taps FIR filter.
 
  -- Kevin Patino <kevin.patino@admobilize.com>  Fri, 18 May 2018 17:00:00 -0500

--- a/src/matrixio-everloop.c
+++ b/src/matrixio-everloop.c
@@ -22,7 +22,7 @@ ssize_t matrixio_everloop_write(struct file *pfile, const char __user *buffer,
 {
 	struct everloop_data *el = pfile->private_data;
 
-		matrixio_write(el->mio, MATRIXIO_EVERLOOP_BASE,length,buffer);
+	matrixio_write(el->mio, MATRIXIO_EVERLOOP_BASE, length, (void *)buffer);
 
 	return length;
 }

--- a/src/matrixio-everloop.c
+++ b/src/matrixio-everloop.c
@@ -21,13 +21,9 @@ ssize_t matrixio_everloop_write(struct file *pfile, const char __user *buffer,
 				size_t length, loff_t *offset)
 {
 	struct everloop_data *el = pfile->private_data;
-	int i;
-	uint16_t value;
-	for (i = 0; i < length; i = i + 2) {
-		value = buffer[i + 1] | buffer[i] << 8;
-		regmap_write(el->mio->regmap, MATRIXIO_EVERLOOP_BASE + (i >> 1),
-			     value);
-	}
+
+		matrixio_write(el->mio, MATRIXIO_EVERLOOP_BASE,length,buffer);
+
 	return length;
 }
 


### PR DESCRIPTION
Change led order from GRWB to RGBW and use buffer write function.

Thank You! : https://github.com/matrix-io/matrixio-kernel-modules/pull/26
