### PR TITLE
Remove unused <asm/uaccess.h> header

### DIFF
--- a/src/matrixio-everloop.c
+++ b/src/matrixio-everloop.c
@@ -1,4 +1,3 @@
-#include <asm/uaccess.h>
 #include <linux/cdev.h>
 #include <linux/fs.h>
 #include <linux/init.h>

--- a/src/matrixio-gpio.c
+++ b/src/matrixio-gpio.c
@@ -1,4 +1,3 @@
-#include <asm/uaccess.h>
 #include <linux/bitops.h>
 #include <linux/fs.h>
 #include <linux/gpio.h>

--- a/src/matrixio-pwm.c
+++ b/src/matrixio-pwm.c
@@ -1,4 +1,3 @@
-#include <asm/uaccess.h>
 #include <linux/fs.h>
 #include <linux/init.h>
 #include <linux/module.h>

--- a/src/matrixio-regmap.c
+++ b/src/matrixio-regmap.c
@@ -1,4 +1,3 @@
-#include <asm/uaccess.h>
 #include <linux/cdev.h>
 #include <linux/fs.h>
 #include <linux/init.h>


### PR DESCRIPTION
<asm/uaccess.h> is not actually used, and causes problem on x86_64. Note that src/matrixio-pwm.c is
not actually compiled into the kernel module, and is unused; modifying for completeness only.

The error message looks like this:

In file included from matrixio-kernel-modules/src/matrixio-gpio.c:1:
./arch/x86/include/asm/uaccess.h:29:27: error: unknown type name ‘mm_segment_t’
   29 | static inline void set_fs(mm_segment_t fs)
      |                           ^~~~~~~~~~~~
In file included from ./arch/x86/include/asm/uaccess.h:7,
                 from matrixio-kernel-modules/src/matrixio-gpio.c:1:
./arch/x86/include/asm/uaccess.h: In function ‘user_access_begin’:
./arch/x86/include/asm/uaccess.h:37:26: error: ‘current’ undeclared (first use in this function)
   37 | #define user_addr_max() (current->thread.addr_limit.seg)
      |                          ^~~~~~~
./include/linux/compiler.h:78:42: note: in definition of macro ‘unlikely’
   78 | # define unlikely(x) __builtin_expect(!!(x), 0)
      |                                          ^
./arch/x86/include/asm/uaccess.h:96:2: note: in expansion of macro ‘likely’
   96 |  likely(!__range_not_ok(addr, size, user_addr_max()));  \
      |  ^~~~~~
./arch/x86/include/asm/uaccess.h:96:10: note: in expansion of macro ‘__range_not_ok’
   96 |  likely(!__range_not_ok(addr, size, user_addr_max()));  \
      |          ^~~~~~~~~~~~~~
./arch/x86/include/asm/uaccess.h:96:37: note: in expansion of macro ‘user_addr_max’
   96 |  likely(!__range_not_ok(addr, size, user_addr_max()));  \
      |                                     ^~~~~~~~~~~~~
./arch/x86/include/asm/uaccess.h:483:16: note: in expansion of macro ‘access_ok’
  483 |  if (unlikely(!access_ok(ptr,len)))
      |                ^~~~~~~~~
./arch/x86/include/asm/uaccess.h:37:26: note: each undeclared identifier is reported only once for each function it appears in
   37 | #define user_addr_max() (current->thread.addr_limit.seg)
      |                          ^~~~~~~
./include/linux/compiler.h:78:42: note: in definition of macro ‘unlikely’
   78 | # define unlikely(x) __builtin_expect(!!(x), 0)
      |                                          ^
./arch/x86/include/asm/uaccess.h:96:2: note: in expansion of macro ‘likely’
   96 |  likely(!__range_not_ok(addr, size, user_addr_max()));  \
      |  ^~~~~~
./arch/x86/include/asm/uaccess.h:96:10: note: in expansion of macro ‘__range_not_ok’
   96 |  likely(!__range_not_ok(addr, size, user_addr_max()));  \
      |          ^~~~~~~~~~~~~~
./arch/x86/include/asm/uaccess.h:96:37: note: in expansion of macro ‘user_addr_max’
   96 |  likely(!__range_not_ok(addr, size, user_addr_max()));  \
      |                                     ^~~~~~~~~~~~~
./arch/x86/include/asm/uaccess.h:483:16: note: in expansion of macro ‘access_ok’
  483 |  if (unlikely(!access_ok(ptr,len)))
      |                ^~~~~~~~~
make[2]: *** [scripts/Makefile.build:281: matrixio-kernel-modules/src/matrixio-gpio.o] Error 1